### PR TITLE
Follow the embedded-hal interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,25 @@
 [package]
 name = "ht16k33"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jason Peacock <jason@jasonpeacock.com>"]
 description = "Rust driver for the Holtek HT16K33 'RAM Mapping 16*8 LED Controller Driver with keyscan'"
-keywords = ["led", "gpio", "driver"]
+keywords = ["led", "driver", "display", "embedded-hal"]
 categories = ["hardware-support"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jasonpeacock/ht16k33"
 readme = "README.md"
 documentation = "https://docs.rs/ht16k33"
 
-[dependencies]
-i2cdev        = "0.4.0"
-num-integer   = "0.1.39"
-slog          = "2.4.1"
-slog-stdlog   = "3.0.4-pre"
-
 [badges]
 is-it-maintained-issue-resolution = { repository = "jasonpeacock/ht16k33" }
 is-it-maintained-open-issues = { repository = "jasonpeacock/ht16k33" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "jasonpeacock/ht16k33", branch = "master" }
+
+[dependencies]
+embedded-hal       = "0.2.2"
+slog               = {version = "2.4.1", features = ["max_level_trace"]}
+slog-stdlog        = "3.0.4-pre"
+
+[dev-dependencies]
+embedded-hal-mock  = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ht16k33
+# HT16K33
 
 [![Version info](https://img.shields.io/crates/v/ht16k33.svg)](https://crates.io/crates/ht16k33)
 [![Documentation](https://docs.rs/ht16k33/badge.svg)](https://docs.rs/ht16k33)
@@ -6,13 +6,25 @@
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/jasonpeacock/ht16k33.svg)](http://isitmaintained.com/project/jasonpeacock/ht16k33 "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/jasonpeacock/ht16k33.svg)](http://isitmaintained.com/project/jasonpeacock/ht16k33 "Percentage of issues still open")
 
-Rust driver for the [Holtek HT16K33 "RAM Mapping 16*8 LED Controller Driver with keyscan"](http://www.holtek.com/productdetail/-/vg/HT16K33).
+Rust driver for the [Holtek HT16K33 "RAM Mapping 16\*8 LED Controller Driver with keyscan"](http://www.holtek.com/productdetail/-/vg/HT16K33).
 
-## Supported Rust Versions
+# Features
+
+- [x] Implements the [`embedded-hal`](https://crates.io/crates/embedded-hal) Interface
+- [x] Displays LEDs
+- [ ] Reads Keyscan
+- [ ] Manages Interrupts
+- [ ] Manages Slave Devices
+
+# Support
+
+For questions, issues, feature requests, and other changes, please file an [issue in the github project](https://github.com/jasonpeacock/ht16k33/issues).
+
+## Rust Versions
 
 See the top of the [Travis configuration file](.travis.yml) for the oldest, and other, supported Rust versions.
 
-## Supported Platforms
+## Platforms
 
 * Linux
     * 32 & 64bit

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# The defaults are good.


### PR DESCRIPTION
This closes #4, closes #6.

* Minor version bump `0.1.0` -> `0.2.0` due to API changes.
* Rewrite implementation to follow the `embedded-hal` interface.
* Rewrite the API to be more consistent & only support chip features.
    * Any `led-bargraph` features have been moved to that crate.
    * Use Enums for feature values.
    * Persist the chip state locally (in-memory).
    * Provide separate APIs for modifying local state or writing
    directly to the chip.
* Rewrite the `I2cMock` implementation to be more useful.
* Added `embedded-hal` keyword for `crates.io`, since we're now
compliant :)
* Use `embedded-hal-mock` for tests, yay!
* Add unit tests.