### PR TITLE
Add support for #![no_std]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ install:
 
 script:
     # Incorporate `TARGET` env var to the build and test process.
-    - cargo build --target $TARGET --verbose
+    - cargo build --target $TARGET --verbose --no-default-features
     - cargo test --target $TARGET --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ travis-ci = { repository = "jasonpeacock/ht16k33", branch = "master" }
 [dependencies]
 bitflags           = "1.0.4"
 embedded-hal       = "0.2.2"
-failure            = "0.1.3"
-failure_derive     = "0.1.3"
 serde              = { version = "1.0.83", optional = true, features = ["derive"] }
 slog               = { version = "2.4.1", features = ["max_level_trace"] }
 slog-stdlog        = "3.0.4-pre"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "ht16k33"
 version = "0.3.0"
 authors = ["Jason Peacock <jason@jasonpeacock.com>"]
@@ -15,13 +16,17 @@ is-it-maintained-open-issues = { repository = "jasonpeacock/ht16k33" }
 maintenance = { status = "actively-developed" }
 travis-ci = { repository = "jasonpeacock/ht16k33", branch = "master" }
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
-bitflags           = "1.0.4"
-embedded-hal       = "0.2.2"
-serde              = { version = "1.0.83", optional = true, features = ["derive"] }
-slog               = { version = "2.4.1", features = ["max_level_trace"] }
-slog-stdlog        = "3.0.4-pre"
+bitflags           = "1.0"
+embedded-hal       = "0.2"
+serde              = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-embedded-hal-mock  = "0.4.0"
-version-sync       = "0.6.0"
+failure            = "0.1"
+embedded-hal-mock  = "0.4"
+version-sync       = "0.6"
+heapless           = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,3 @@ serde              = { version = "1.0", optional = true, features = ["derive"] }
 failure            = "0.1"
 embedded-hal-mock  = "0.4"
 version-sync       = "0.6"
-heapless           = "0.4"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently, only the 28-pin SOP package type is supported.
 # Features
 
 - [x] Uses the [`embedded-hal`](https://crates.io/crates/embedded-hal) hardware abstraction.
-- [ ] Supports `no_std` for embedded devices.
+- [x] Supports `no_std` for embedded devices.
 - [ ] Supports all 20/24/28-pin SOP package types.
 - [x] Displays all 128 LEDs.
 - [ ] Reads keyscan.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,11 +1,9 @@
+use std::fmt;
+
 /// Errors encountered during validation.
-#[derive(Debug, Fail)]
+#[derive(Debug)]
 pub enum ValidationError {
     /// The value is too large.
-    #[fail(
-        display = "'{}' value [{}] must be less than (or equal: {}) [{}])",
-        name, value, inclusive, limit
-    )]
     ValueTooLarge {
         /// Name of the value.
         name: String,
@@ -16,4 +14,21 @@ pub enum ValidationError {
         /// Whether the limit is inclusive or not.
         inclusive: bool,
     },
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ValidationError::ValueTooLarge {
+                name,
+                value,
+                limit,
+                inclusive,
+            } => write!(
+                f,
+                "'{}' value [{}] must be less than (or equal: {}) [{}])",
+                name, value, limit, inclusive
+            ),
+        }
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 /// Errors encountered during validation.
 #[derive(Debug)]
@@ -6,7 +6,7 @@ pub enum ValidationError {
     /// The value is too large.
     ValueTooLarge {
         /// Name of the value.
-        name: String,
+        name: &'static str,
         /// Value that failed validation.
         value: u8,
         /// Limit that the value exceeded.
@@ -15,6 +15,12 @@ pub enum ValidationError {
         inclusive: bool,
     },
 }
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
+impl std::error::Error for ValidationError {}
 
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/i2c_mock.rs
+++ b/src/i2c_mock.rs
@@ -4,6 +4,8 @@
 //! not have I2C support.
 extern crate embedded_hal as hal;
 
+use std::fmt;
+
 use slog::Drain;
 use slog::Logger;
 use slog_stdlog::StdLog;
@@ -12,9 +14,14 @@ use constants::ROWS_SIZE;
 use types::DisplayDataAddress;
 
 /// Mock error to satisfy the I2C trait.
-#[derive(Debug, Fail)]
-#[fail(display = "I2cMock Error")]
+#[derive(Debug)]
 pub struct I2cMockError;
+
+impl fmt::Display for I2cMockError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "I2c MockError")
+    }
+}
 
 /// The mock I2C state.
 ///

--- a/src/i2c_mock.rs
+++ b/src/i2c_mock.rs
@@ -2,20 +2,19 @@
 //!
 //! A mock I2C library to support using the [HT16K33](../struct.HT16K33.html) driver on non-Linux systems that do
 //! not have I2C support.
-extern crate embedded_hal as hal;
+use embedded_hal as hal;
 
-use std::fmt;
+use core::fmt;
 
-use slog::Drain;
-use slog::Logger;
-use slog_stdlog::StdLog;
-
-use constants::ROWS_SIZE;
-use types::DisplayDataAddress;
+use crate::constants::ROWS_SIZE;
+use crate::types::DisplayDataAddress;
 
 /// Mock error to satisfy the I2C trait.
 #[derive(Debug)]
 pub struct I2cMockError;
+
+#[cfg(feature = "std")]
+impl std::error::Error for I2cMockError {}
 
 impl fmt::Display for I2cMockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -28,48 +27,24 @@ impl fmt::Display for I2cMockError {
 /// # Example
 ///
 /// ```
-/// // NOTE: `None` is used for the Logger in these examples for convenience,
-/// // in practice using an actual logger is preferred.
-///
-/// extern crate ht16k33;
 /// use ht16k33::i2c_mock::I2cMock;
 /// # fn main() {
 ///
 /// // Create an I2cMock.
-/// let i2c_mock = I2cMock::new(None);
+/// let i2c_mock = I2cMock::new();
 ///
 /// # }
 /// ```
 pub struct I2cMock {
     /// Display RAM state.
     pub data_values: [u8; ROWS_SIZE],
-    logger: Logger,
 }
 
 impl I2cMock {
     /// Create an I2cMock.
-    ///
-    /// # Arguments
-    ///
-    /// * `logger` - A logging instance.
-    ///
-    /// # Notes
-    ///
-    /// `logger = None`, will log to the `slog-stdlog` drain. This makes the library
-    /// effectively work the same as if it was just using `log` instead of `slog`.
-    pub fn new<L>(logger: L) -> Self
-    where
-        L: Into<Option<Logger>>,
-    {
-        let logger = logger
-            .into()
-            .unwrap_or_else(|| Logger::root(StdLog.fuse(), o!()));
-
-        trace!(logger, "Constructing I2cMock");
-
+    pub fn new() -> Self {
         I2cMock {
             data_values: [0; ROWS_SIZE],
-            logger,
         }
     }
 }
@@ -88,12 +63,10 @@ impl hal::blocking::i2c::WriteRead for I2cMock {
     /// # Examples
     ///
     /// ```
-    /// # extern crate embedded_hal;
-    /// # extern crate ht16k33;
     /// # use embedded_hal::blocking::i2c::WriteRead;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # fn main() {
-    /// let mut i2c_mock = I2cMock::new(None);
+    /// let mut i2c_mock = I2cMock::new();
     ///
     /// let mut read_buffer = [0u8; 16];
     /// i2c_mock.write_read(0, &[ht16k33::DisplayDataAddress::ROW_0.bits()], &mut read_buffer);
@@ -102,12 +75,10 @@ impl hal::blocking::i2c::WriteRead for I2cMock {
     /// ```
     fn write_read(
         &mut self,
-        address: u8,
+        _address: u8,
         bytes: &[u8],
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
-        trace!(self.logger, "write_read"; "address" => address, "bytes" => format!("{:?}", bytes), "buffer" => format!("{:?}", buffer));
-
         // The `bytes` have the `data_address` command + index to start reading from,
         // need to clear the command to extract the starting index.
         let mut data_offset = (bytes[0] ^ DisplayDataAddress::ROW_0.bits()) as usize;
@@ -136,12 +107,10 @@ impl hal::blocking::i2c::Write for I2cMock {
     /// # Examples
     ///
     /// ```
-    /// # extern crate embedded_hal;
-    /// # extern crate ht16k33;
     /// # use embedded_hal::blocking::i2c::Write;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # fn main() {
-    /// let mut i2c_mock = I2cMock::new(None);
+    /// let mut i2c_mock = I2cMock::new();
     ///
     /// // First value is the data address, remaining values are to be written
     /// // starting at the data address which auto-increments and then wraps.
@@ -151,9 +120,7 @@ impl hal::blocking::i2c::Write for I2cMock {
     ///
     /// # }
     /// ```
-    fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        trace!(self.logger, "write"; "address" => address, "bytes" => format!("{:?}", bytes));
-
+    fn write(&mut self, _address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         // "Command-only" writes are length 1 and write-only, and cannot be read back,
         // discard them for simplicity.
         if bytes.len() == 1 {
@@ -184,12 +151,12 @@ mod tests {
 
     #[test]
     fn new() {
-        let _i2c_mock = I2cMock::new(None);
+        let _i2c_mock = I2cMock::new();
     }
 
     #[test]
     fn write() {
-        let mut i2c_mock = I2cMock::new(None);
+        let mut i2c_mock = I2cMock::new();
 
         let write_buffer = [super::DisplayDataAddress::ROW_0.bits(), 1u8, 1u8];
         i2c_mock.write(ADDRESS, &write_buffer).unwrap();
@@ -212,7 +179,7 @@ mod tests {
 
     #[test]
     fn write_with_offset() {
-        let mut i2c_mock = I2cMock::new(None);
+        let mut i2c_mock = I2cMock::new();
 
         let offset = 4u8;
         let write_buffer = [super::DisplayDataAddress::ROW_0.bits() | offset, 1u8, 1u8];
@@ -236,7 +203,7 @@ mod tests {
 
     #[test]
     fn write_with_wraparound() {
-        let mut i2c_mock = I2cMock::new(None);
+        let mut i2c_mock = I2cMock::new();
 
         // Match the data values size, +2 to wrap around, +1 for the data command.
         let mut write_buffer = [1u8; super::ROWS_SIZE + 3];
@@ -266,7 +233,7 @@ mod tests {
 
     #[test]
     fn write_with_wraparound_and_offset() {
-        let mut i2c_mock = I2cMock::new(None);
+        let mut i2c_mock = I2cMock::new();
 
         // Match the data values size, +2 to wrap around, +1 for the data command.
         let mut write_buffer = [1u8; super::ROWS_SIZE + 3];
@@ -298,7 +265,7 @@ mod tests {
 
     #[test]
     fn write_read() {
-        let mut i2c_mock = I2cMock::new(None);
+        let mut i2c_mock = I2cMock::new();
 
         i2c_mock.data_values[0] = 1;
         i2c_mock.data_values[1] = 1;
@@ -330,7 +297,7 @@ mod tests {
 
     #[test]
     fn write_read_offset() {
-        let mut i2c_mock = I2cMock::new(None);
+        let mut i2c_mock = I2cMock::new();
 
         i2c_mock.data_values[2] = 1;
         i2c_mock.data_values[3] = 1;
@@ -364,7 +331,7 @@ mod tests {
 
     #[test]
     fn write_read_wraparound() {
-        let mut i2c_mock = I2cMock::new(None);
+        let mut i2c_mock = I2cMock::new();
 
         i2c_mock.data_values[2] = 1;
         i2c_mock.data_values[3] = 1;
@@ -397,7 +364,7 @@ mod tests {
 
     #[test]
     fn write_read_wraparound_and_offset() {
-        let mut i2c_mock = I2cMock::new(None);
+        let mut i2c_mock = I2cMock::new();
 
         i2c_mock.data_values[0] = 1;
         i2c_mock.data_values[1] = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,13 +70,9 @@
 #![doc(html_root_url = "https://docs.rs/ht16k33/0.3.0")]
 #![deny(missing_docs)]
 extern crate embedded_hal as hal;
-extern crate failure;
 
 #[macro_use]
 extern crate bitflags;
-
-#[macro_use]
-extern crate failure_derive;
 
 #[cfg(feature = "serde")]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,14 @@
 //! # }
 //! ```
 //!
+//! ## Embedded platforms
+//!
+//! Using this crate without default features in your `Cargo.toml` like so:
+//! ```toml
+//! [dependencies]
+//! htk16k33 = { version = "*", features = [] }
+//! ```
+//!
 //! ## All platforms, using I2C simulation
 //!
 //! Not all platforms have I2C support. The provided `ht16k33::i2c_mock` implements the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! # Features
 //!
 //! - [x] Uses the [`embedded-hal`](https://crates.io/crates/embedded-hal) hardware abstraction.
-//! - [ ] Supports `no_std` for embedded devices.
+//! - [x] Supports `no_std` for embedded devices.
 //! - [ ] Supports all 20/24/28-pin SOP package types.
 //! - [x] Displays all 128 LEDs.
 //! - [ ] Reads keyscan.
@@ -16,21 +16,15 @@
 //!
 //! # Usage
 //!
-//! *NOTE: `None` is used for the Logger in these examples for convenience, in practice using an
-//! actual logger is preferred.*
-//!
 //! ## Linux-based platforms
 //!
 //! Using the recommended [`linux-embedded-hal`](https://crates.io/crates/linux-embedded-hal)
 //! crate which implements the `embedded-hal` traits for Linux devices, including I2C.
 //!
-//! ```ignore
-//! extern crate linux_embedded_hal;
-//! extern crate ht16k33;
-//!
+//! ```!ignore
+//! # use failure::Error;
 //! use linux_embedded_hal::I2cdev;
 //! use ht16k33::HT16K33;
-//! # use std::error::Error;
 //! # fn main() -> Result<(), Error>{
 //!
 //! // The I2C device address.
@@ -40,7 +34,7 @@
 //! let mut i2c = I2cdev::new("/path/to/i2c/device")?;
 //! i2c.set_slave_address(address as u16)?;
 //!
-//! let mut ht16k33 = HT16K33::new(i2c, address, None);
+//! let mut ht16k33 = HT16K33::new(i2c, address);
 //!
 //! # Ok(())
 //! # }
@@ -52,7 +46,7 @@
 //! `embedded-hal` traits for I2C.
 //!
 //! ```
-//! extern crate ht16k33;
+//! # use failure::Error;
 //! use ht16k33::i2c_mock::I2cMock;
 //! use ht16k33::HT16K33;
 //! # fn main() {
@@ -61,30 +55,19 @@
 //! let address = 112u8;
 //!
 //! // Create a mock I2C device.
-//! let mut i2c = I2cMock::new(None);
+//! let mut i2c = I2cMock::new();
 //!
-//! let mut ht16k33 = HT16K33::new(i2c, address, None);
+//! let mut ht16k33 = HT16K33::new(i2c, address);
 //!
 //! # }
 //! ```
+#![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_root_url = "https://docs.rs/ht16k33/0.3.0")]
 #![deny(missing_docs)]
-extern crate embedded_hal as hal;
-
-#[macro_use]
-extern crate bitflags;
+use embedded_hal as hal;
 
 #[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
-
-/// Re-export slog
-///
-/// Users of this library can, but don't have to, use slog to build their own loggers.
-#[macro_use]
-pub extern crate slog;
-
-extern crate slog_stdlog;
+use serde;
 
 mod constants;
 mod errors;
@@ -97,7 +80,6 @@ pub use types::{Dimming, Display, DisplayData, DisplayDataAddress, LedLocation, 
 
 pub use constants::{COMMONS_SIZE, ROWS_SIZE};
 use hal::blocking::i2c::{Write, WriteRead};
-use slog::Drain;
 
 /// The HT16K33 state and configuration.
 pub struct HT16K33<I2C> {
@@ -116,8 +98,6 @@ pub struct HT16K33<I2C> {
     oscillator_state: Oscillator,
     display_state: Display,
     dimming_state: Dimming,
-
-    logger: slog::Logger,
 }
 
 impl<I2C, E> HT16K33<I2C>
@@ -129,44 +109,25 @@ where
     /// # Arguments
     ///
     /// * `i2c` - The I2C device to communicate with the HT16K33 chip.
-    /// * `logger` - A logging instance.
-    ///
-    /// # Notes
-    ///
-    /// `logger = None` will log to the `slog-stdlog` drain. This makes the library
-    /// effectively work the same as if it was just using `log` instead of `slog`.
     ///
     /// # Examples
     ///
     /// ```
-    /// // NOTE: `None` is used for the Logger in these examples for convenience,
-    /// // in practice using an actual logger is preferred.
-    ///
-    /// extern crate ht16k33;
     /// use ht16k33::i2c_mock::I2cMock;
     /// use ht16k33::HT16K33;
     /// # fn main() {
     ///
     /// // Create an I2C device.
-    /// let mut i2c = I2cMock::new(None);
+    /// let mut i2c = I2cMock::new();
     ///
     /// // The I2C device address.
     /// let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     ///
     /// # }
     /// ```
-    pub fn new<L>(i2c: I2C, address: u8, logger: L) -> Self
-    where
-        L: Into<Option<slog::Logger>>,
-    {
-        let logger = logger
-            .into()
-            .unwrap_or_else(|| slog::Logger::root(slog_stdlog::StdLog.fuse(), o!()));
-
-        trace!(logger, "Constructing HT16K33");
-
+    pub fn new(i2c: I2C, address: u8) -> Self {
         // Configure the initial values to match the power-on defaults.
         HT16K33 {
             address,
@@ -175,7 +136,6 @@ where
             oscillator_state: Oscillator::OFF,
             display_state: Display::OFF,
             dimming_state: Dimming::BRIGHTNESS_MAX,
-            logger,
         }
     }
 
@@ -184,16 +144,14 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate failure;
-    /// # extern crate ht16k33;
     /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// # fn main() -> Result<(), Error> {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// ht16k33.initialize()?;
     ///
     /// # Ok(())
@@ -219,14 +177,14 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate ht16k33;
+    /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// # fn main() {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// i2c = ht16k33.destroy();
     ///
     /// # }
@@ -242,21 +200,19 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate ht16k33;
+    /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// # fn main() {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// let &buffer = ht16k33.display_buffer();
     ///
     /// # }
     /// ```
     pub fn display_buffer(&self) -> &[DisplayData; ROWS_SIZE] {
-        trace!(self.logger, "display_buffer");
-
         &self.buffer
     }
 
@@ -265,21 +221,19 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate ht16k33;
+    /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// # fn main() {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// let oscillator = ht16k33.oscillator();
     ///
     /// # }
     /// ```
     pub fn oscillator(&self) -> &Oscillator {
-        trace!(self.logger, "oscillator");
-
         &self.oscillator_state
     }
 
@@ -288,21 +242,19 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate ht16k33;
+    /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// # fn main() {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// let display = ht16k33.display();
     ///
     /// # }
     /// ```
     pub fn display(&self) -> &Display {
-        trace!(self.logger, "display");
-
         &self.display_state
     }
 
@@ -311,21 +263,19 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate ht16k33;
+    /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// # fn main() {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// let dimming = ht16k33.dimming();
     ///
     /// # }
     /// ```
     pub fn dimming(&self) -> &Dimming {
-        trace!(self.logger, "dimming");
-
         &self.dimming_state
     }
 
@@ -342,17 +292,15 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate failure;
-    /// # extern crate ht16k33;
-    /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
+    /// # use ht16k33::ValidationError;
     /// use ht16k33::LedLocation;
-    /// # fn main() -> Result<(), Error> {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # fn main() -> Result<(), ValidationError> {
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     ///
     /// let led_location = LedLocation::new(0, 0)?;
     /// ht16k33.update_display_buffer(led_location, true);
@@ -362,7 +310,6 @@ where
     /// ```
     pub fn update_display_buffer(&mut self, location: LedLocation, enabled: bool) {
         // TODO Validate `address` parameter.
-        trace!(self.logger, "update_display_buffer"; "location" => format!("{:?}", location), "enabled" => enabled);
 
         // Turn on/off the specified LED.
         self.buffer[location.row_as_index()].set(location.common, enabled);
@@ -376,21 +323,18 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate ht16k33;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// # fn main() {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// ht16k33.clear_display_buffer();
     ///
     /// # }
     /// ```
     pub fn clear_display_buffer(&mut self) {
-        trace!(self.logger, "clear_display_buffer");
-
         // TODO is there any advantage to iteration vs just assigning
         // a new, empty `[0; ROWS_SIZE]` array?
         for row in self.buffer.iter_mut() {
@@ -407,25 +351,21 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate failure;
-    /// # extern crate ht16k33;
     /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// use ht16k33::Oscillator;
     /// # fn main() -> Result<(), Error> {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// ht16k33.set_oscillator(Oscillator::ON)?;
     ///
     /// # Ok(())
     /// # }
     /// ```
     pub fn set_oscillator(&mut self, oscillator: Oscillator) -> Result<(), E> {
-        trace!(self.logger, "set_oscillator"; "oscillator" => format!("{:?}", oscillator));
-
         self.oscillator_state = oscillator;
 
         self.i2c.write(
@@ -445,27 +385,21 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate failure;
-    /// # extern crate ht16k33;
     /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// use ht16k33::Display;
     /// # fn main() -> Result<(), Error> {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// ht16k33.set_display(Display::HALF_HZ)?;
     ///
     /// # Ok(())
     /// # }
     /// ```
     pub fn set_display(&mut self, display: Display) -> Result<(), E> {
-        trace!(self.logger, "set_display";
-        "display" => format!("{:?}", display),
-        );
-
         self.display_state = display;
 
         self.i2c.write(
@@ -485,25 +419,21 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate failure;
-    /// # extern crate ht16k33;
     /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// use ht16k33::Dimming;
     /// # fn main() -> Result<(), Error> {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// ht16k33.set_dimming(Dimming::from_u8(4)?)?;
     ///
     /// # Ok(())
     /// # }
     /// ```
     pub fn set_dimming(&mut self, dimming: Dimming) -> Result<(), E> {
-        trace!(self.logger, "set_dimming"; "dimming" => format!("{:?}", dimming));
-
         self.dimming_state = dimming;
 
         self.i2c.write(
@@ -524,17 +454,15 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate failure;
-    /// # extern crate ht16k33;
     /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// use ht16k33::LedLocation;
     /// # fn main() -> Result<(), Error> {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     ///
     /// let led_location = LedLocation::new(0, 0)?;
     /// ht16k33.set_led(led_location, true)?;
@@ -544,8 +472,6 @@ where
     /// ```
     pub fn set_led(&mut self, location: LedLocation, enabled: bool) -> Result<(), E> {
         // TODO Validate `address` parameter.
-        trace!(self.logger, "set_led"; "location" => format!("{:?}", location), "enabled" => enabled);
-
         self.update_display_buffer(location, enabled);
 
         self.i2c.write(
@@ -564,23 +490,20 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate ht16k33;
+    /// # use failure::Error;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
-    /// # use std::error::Error;
     /// # fn main() -> Result<(), Box<Error>> {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// ht16k33.write_display_buffer();
     ///
     /// # Ok(())
     /// # }
     /// ```
     pub fn write_display_buffer(&mut self) -> Result<(), E> {
-        trace!(self.logger, "write_display_buffer"; "buffer" => format!("{:?}", self.buffer));
-
         let mut write_buffer = [0u8; ROWS_SIZE + 1];
         write_buffer[0] = DisplayDataAddress::ROW_0.bits();
 
@@ -598,23 +521,20 @@ where
     /// # Examples
     ///
     /// ```
-    /// # extern crate ht16k33;
     /// # use ht16k33::i2c_mock::I2cMock;
     /// # use ht16k33::HT16K33;
     /// # use std::error::Error;
     /// # fn main() -> Result<(), Box<Error>> {
-    /// # let mut i2c = I2cMock::new(None);
+    /// # let mut i2c = I2cMock::new();
     /// # let address = 0u8;
     ///
-    /// let mut ht16k33 = HT16K33::new(i2c, address, None);
+    /// let mut ht16k33 = HT16K33::new(i2c, address);
     /// ht16k33.read_display_buffer();
     ///
     /// # Ok(())
     /// # }
     /// ```
     pub fn read_display_buffer(&mut self) -> Result<(), E> {
-        trace!(self.logger, "read_display_buffer"; "buffer" => format!("{:?}", self.buffer));
-
         let mut read_buffer = [0u8; ROWS_SIZE];
 
         self.i2c.write_read(
@@ -633,10 +553,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate embedded_hal_mock as hal;
+    extern crate std;
+    use embedded_hal_mock as hal;
 
     use self::hal::i2c::{Mock as I2cMock, Transaction as I2cTransaction};
     use super::*;
+
+    use std::vec;
 
     const ADDRESS: u8 = 0;
 
@@ -645,7 +568,7 @@ mod tests {
         let expectations = [];
 
         let mut i2c = I2cMock::new(&expectations);
-        let ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         i2c = ht16k33.destroy();
         i2c.done();
@@ -673,7 +596,7 @@ mod tests {
         ];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         ht16k33.initialize().unwrap();
 
@@ -686,7 +609,7 @@ mod tests {
         let expectations = [];
 
         let mut i2c = I2cMock::new(&expectations);
-        let ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         let &buffer = ht16k33.display_buffer();
 
@@ -707,7 +630,7 @@ mod tests {
         let expectations = [];
 
         let mut i2c = I2cMock::new(&expectations);
-        let ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         let &oscillator = ht16k33.oscillator();
 
@@ -722,7 +645,7 @@ mod tests {
         let expectations = [];
 
         let mut i2c = I2cMock::new(&expectations);
-        let ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         let &display = ht16k33.display();
 
@@ -737,7 +660,7 @@ mod tests {
         let expectations = [];
 
         let mut i2c = I2cMock::new(&expectations);
-        let ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         let &dimming = ht16k33.dimming();
 
@@ -752,7 +675,7 @@ mod tests {
         let expectations = [];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         let first_led = LedLocation::new(1, 4).unwrap();
         let second_led = LedLocation::new(1, 5).unwrap();
@@ -778,7 +701,7 @@ mod tests {
         let expectations = [];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         let first_led = LedLocation::new(1, 4).unwrap();
         let second_led = LedLocation::new(1, 5).unwrap();
@@ -812,7 +735,7 @@ mod tests {
         )];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         ht16k33.set_oscillator(super::Oscillator::OFF).unwrap();
 
@@ -828,7 +751,7 @@ mod tests {
         )];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         ht16k33.set_display(super::Display::OFF).unwrap();
 
@@ -844,7 +767,7 @@ mod tests {
         )];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         ht16k33.set_dimming(Dimming::BRIGHTNESS_MAX).unwrap();
 
@@ -857,7 +780,7 @@ mod tests {
         let expectations = [I2cTransaction::write(ADDRESS, vec![1u8, 0b1000_0000])];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         ht16k33
             .set_led(LedLocation::new(1, 7).unwrap(), true)
@@ -875,7 +798,7 @@ mod tests {
         let expectations = [I2cTransaction::write(ADDRESS, write_buffer)];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         ht16k33.write_display_buffer().unwrap();
 
@@ -896,7 +819,7 @@ mod tests {
         )];
 
         let mut i2c = I2cMock::new(&expectations);
-        let mut ht16k33 = HT16K33::new(i2c, ADDRESS, None);
+        let mut ht16k33 = HT16K33::new(i2c, ADDRESS);
 
         ht16k33.read_display_buffer().unwrap();
 

--- a/src/types/dimming.rs
+++ b/src/types/dimming.rs
@@ -1,7 +1,6 @@
-use errors::ValidationError;
-
-use std::default;
-use std::fmt;
+use crate::errors::ValidationError;
+use bitflags::bitflags;
+use core::fmt;
 
 bitflags! {
     /// Display dimming.
@@ -58,7 +57,7 @@ bitflags! {
     }
 }
 
-impl default::Default for Dimming {
+impl Default for Dimming {
     fn default() -> Dimming {
         Dimming::BRIGHTNESS_MAX
     }
@@ -88,11 +87,9 @@ impl Dimming {
     /// # Example
     ///
     /// ```
-    /// # extern crate failure;
-    /// # extern crate ht16k33;
-    /// # use failure::Error;
     /// use ht16k33::Dimming;
-    /// # fn main() -> Result<(), Error> {
+    /// # use ht16k33::ValidationError;
+    /// # fn main() -> Result<(), ValidationError> {
     ///
     /// let brightness = Dimming::from_u8(1u8)?;
     ///
@@ -105,7 +102,6 @@ impl Dimming {
     /// # Error Example
     ///
     /// ```should_panic
-    /// # extern crate ht16k33;
     /// use ht16k33::Dimming;
     /// use ht16k33::ValidationError;
     /// # fn main() {
@@ -128,7 +124,7 @@ impl Dimming {
     pub fn from_u8(value: u8) -> Result<Self, ValidationError> {
         if value > Dimming::BRIGHTNESS_MAX.bits() {
             return Err(ValidationError::ValueTooLarge {
-                name: "Dimming".to_string(),
+                name: "dimming",
                 value,
                 limit: Dimming::BRIGHTNESS_MAX.bits(),
                 inclusive: true,

--- a/src/types/display.rs
+++ b/src/types/display.rs
@@ -1,5 +1,5 @@
-use std::default;
-use std::fmt;
+use bitflags::bitflags;
+use core::fmt;
 
 bitflags! {
     /// The LED display state.
@@ -23,7 +23,7 @@ bitflags! {
     }
 }
 
-impl default::Default for Display {
+impl Default for Display {
     fn default() -> Display {
         Display::OFF
     }

--- a/src/types/display_data.rs
+++ b/src/types/display_data.rs
@@ -1,5 +1,5 @@
-use std::default;
-use std::fmt;
+use bitflags::bitflags;
+use core::fmt;
 
 bitflags! {
     /// RAM data for LED display.
@@ -27,7 +27,7 @@ bitflags! {
     }
 }
 
-impl default::Default for DisplayData {
+impl Default for DisplayData {
     fn default() -> DisplayData {
         DisplayData::COMMON_NONE
     }

--- a/src/types/display_data_address.rs
+++ b/src/types/display_data_address.rs
@@ -1,5 +1,5 @@
-use std::default;
-use std::fmt;
+use bitflags::bitflags;
+use core::fmt;
 
 bitflags! {
     /// Display RAM data address.
@@ -39,7 +39,7 @@ bitflags! {
     }
 }
 
-impl default::Default for DisplayDataAddress {
+impl Default for DisplayDataAddress {
     fn default() -> DisplayDataAddress {
         DisplayDataAddress::ROW_0
     }

--- a/src/types/led_location.rs
+++ b/src/types/led_location.rs
@@ -1,11 +1,9 @@
-use errors::ValidationError;
+use crate::constants::{COMMONS_SIZE, ROWS_SIZE};
+use crate::errors::ValidationError;
+use crate::types::DisplayData;
+use crate::types::DisplayDataAddress;
 
-use std::fmt;
-
-use constants::{COMMONS_SIZE, ROWS_SIZE};
-
-use types::DisplayData;
-use types::DisplayDataAddress;
+use core::fmt;
 
 /// Represents the LED location.
 ///
@@ -15,13 +13,11 @@ use types::DisplayDataAddress;
 /// # Example
 ///
 /// ```
-/// # extern crate failure;
-/// extern crate ht16k33;
-/// # use failure::Error;
 /// use ht16k33::LedLocation;
 /// use ht16k33::DisplayData;
 /// use ht16k33::DisplayDataAddress;
-/// # fn main() -> Result<(), Error>{
+/// use ht16k33::ValidationError;
+/// # fn main() -> Result<(), ValidationError>{
 ///
 /// let row = 1u8;
 /// let common = 2u8;
@@ -66,7 +62,6 @@ impl LedLocation {
     /// [`ht16k33::ValidationError::ValueTooLarge`]: enum.ValidationError.html#variant.ValueTooLarge
     ///
     /// ```should_panic
-    /// # extern crate ht16k33;
     /// use ht16k33::LedLocation;
     /// use ht16k33::ValidationError;
     /// # use ht16k33::ROWS_SIZE;
@@ -85,7 +80,7 @@ impl LedLocation {
     pub fn new(row: u8, common: u8) -> Result<Self, ValidationError> {
         if row >= ROWS_SIZE as u8 {
             return Err(ValidationError::ValueTooLarge {
-                name: "Row".to_string(),
+                name: "row",
                 value: row,
                 limit: ROWS_SIZE as u8,
                 inclusive: false,
@@ -94,7 +89,7 @@ impl LedLocation {
 
         if common >= COMMONS_SIZE as u8 {
             return Err(ValidationError::ValueTooLarge {
-                name: "Common".to_string(),
+                name: "common",
                 value: common,
                 limit: COMMONS_SIZE as u8,
                 inclusive: false,

--- a/src/types/oscillator.rs
+++ b/src/types/oscillator.rs
@@ -1,5 +1,5 @@
-use std::default;
-use std::fmt;
+use bitflags::bitflags;
+use core::fmt;
 
 bitflags! {
     /// System oscillator setup and control.
@@ -15,7 +15,7 @@ bitflags! {
     }
 }
 
-impl default::Default for Oscillator {
+impl Default for Oscillator {
     fn default() -> Oscillator {
         Oscillator::OFF
     }

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate version_sync;
+use version_sync::{assert_html_root_url_updated, assert_markdown_deps_updated};
 
 #[test]
 fn test_readme_deps() {


### PR DESCRIPTION
The default features include the `std` (to be able to run `cargo test` on the host PC).

Among the things I took the liberty of doing in-order to support `#![no_std]`:
- Remove usage of `failure` and implement `core::fmt::Display` and optionally `std::error::Error` where needed
- Remove logging, it will never work on embedded platforms and I feel at this level `gdb` is usually more helpful

Fixes #7