### PR TITLE
Use common-based addressing instead of row-based.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "ht16k33"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jason Peacock <jason@jasonpeacock.com>"]
 description = "Rust driver for the Holtek HT16K33 'RAM Mapping 16*8 LED Controller Driver with keyscan'"
 keywords = ["no-std", "led", "driver", "display", "embedded-hal"]

--- a/src/i2c_mock.rs
+++ b/src/i2c_mock.rs
@@ -81,7 +81,7 @@ impl hal::blocking::i2c::WriteRead for I2cMock {
     ) -> Result<(), Self::Error> {
         // The `bytes` have the `data_address` command + index to start reading from,
         // need to clear the command to extract the starting index.
-        let mut data_offset = (bytes[0] ^ DisplayDataAddress::ROW_0.bits()) as usize;
+        let mut data_offset = (bytes[0] ^ DisplayDataAddress::COMMON_0.bits()) as usize;
 
         for value in buffer.iter_mut() {
             *value = self.data_values[data_offset];
@@ -128,7 +128,7 @@ impl hal::blocking::i2c::Write for I2cMock {
         }
 
         // Other writes have data, store them.
-        let mut data_offset = (bytes[0] ^ DisplayDataAddress::ROW_0.bits()) as usize;
+        let mut data_offset = (bytes[0] ^ DisplayDataAddress::COMMON_0.bits()) as usize;
         let data = &bytes[1..];
 
         for value in data.iter() {

--- a/src/i2c_mock.rs
+++ b/src/i2c_mock.rs
@@ -69,7 +69,7 @@ impl hal::blocking::i2c::WriteRead for I2cMock {
     /// let mut i2c_mock = I2cMock::new();
     ///
     /// let mut read_buffer = [0u8; 16];
-    /// i2c_mock.write_read(0, &[ht16k33::DisplayDataAddress::ROW_0.bits()], &mut read_buffer);
+    /// i2c_mock.write_read(0, &[ht16k33::DisplayDataAddress::COMMON_0.bits()], &mut read_buffer);
     ///
     /// # }
     /// ```
@@ -114,7 +114,7 @@ impl hal::blocking::i2c::Write for I2cMock {
     ///
     /// // First value is the data address, remaining values are to be written
     /// // starting at the data address which auto-increments and then wraps.
-    /// let write_buffer = [ht16k33::DisplayDataAddress::ROW_0.bits(), 0u8, 0u8];
+    /// let write_buffer = [ht16k33::DisplayDataAddress::COMMON_0.bits(), 0u8, 0u8];
     ///
     /// i2c_mock.write(0, &write_buffer);
     ///
@@ -158,7 +158,7 @@ mod tests {
     fn write() {
         let mut i2c_mock = I2cMock::new();
 
-        let write_buffer = [super::DisplayDataAddress::ROW_0.bits(), 1u8, 1u8];
+        let write_buffer = [super::DisplayDataAddress::COMMON_0.bits(), 1u8, 1u8];
         i2c_mock.write(ADDRESS, &write_buffer).unwrap();
 
         for value in 0..i2c_mock.data_values.len() {
@@ -182,7 +182,7 @@ mod tests {
         let mut i2c_mock = I2cMock::new();
 
         let offset = 4u8;
-        let write_buffer = [super::DisplayDataAddress::ROW_0.bits() | offset, 1u8, 1u8];
+        let write_buffer = [super::DisplayDataAddress::COMMON_0.bits() | offset, 1u8, 1u8];
         i2c_mock.write(ADDRESS, &write_buffer).unwrap();
 
         for value in 0..i2c_mock.data_values.len() {
@@ -207,7 +207,7 @@ mod tests {
 
         // Match the data values size, +2 to wrap around, +1 for the data command.
         let mut write_buffer = [1u8; super::ROWS_SIZE + 3];
-        write_buffer[0] = super::DisplayDataAddress::ROW_0.bits();
+        write_buffer[0] = super::DisplayDataAddress::COMMON_0.bits();
 
         // These values should wrap and end up at indexes 0 & 1.
         write_buffer[write_buffer.len() - 1] = 2;
@@ -239,7 +239,7 @@ mod tests {
         let mut write_buffer = [1u8; super::ROWS_SIZE + 3];
 
         let offset = 4u8;
-        write_buffer[0] = super::DisplayDataAddress::ROW_0.bits() | offset;
+        write_buffer[0] = super::DisplayDataAddress::COMMON_0.bits() | offset;
 
         // These values should wrap and end up at indexes 4 & 5.
         write_buffer[write_buffer.len() - 1] = 2;
@@ -274,7 +274,7 @@ mod tests {
         i2c_mock
             .write_read(
                 ADDRESS,
-                &[super::DisplayDataAddress::ROW_0.bits()],
+                &[super::DisplayDataAddress::COMMON_0.bits()],
                 &mut read_buffer,
             )
             .unwrap();
@@ -308,7 +308,7 @@ mod tests {
         i2c_mock
             .write_read(
                 ADDRESS,
-                &[super::DisplayDataAddress::ROW_0.bits() | offset],
+                &[super::DisplayDataAddress::COMMON_0.bits() | offset],
                 &mut read_buffer,
             )
             .unwrap();
@@ -341,7 +341,7 @@ mod tests {
         i2c_mock
             .write_read(
                 ADDRESS,
-                &[super::DisplayDataAddress::ROW_0.bits()],
+                &[super::DisplayDataAddress::COMMON_0.bits()],
                 &mut read_buffer,
             )
             .unwrap();
@@ -375,7 +375,7 @@ mod tests {
         i2c_mock
             .write_read(
                 ADDRESS,
-                &[super::DisplayDataAddress::ROW_0.bits() | offset],
+                &[super::DisplayDataAddress::COMMON_0.bits() | offset],
                 &mut read_buffer,
             )
             .unwrap();

--- a/src/types/display_data.rs
+++ b/src/types/display_data.rs
@@ -5,46 +5,70 @@ bitflags! {
     /// RAM data for LED display.
     ///
     /// The LED for the corresponding bitflag will be enabled if the flag is `1`.
-    pub struct DisplayData: u8 {
+    pub struct DisplayData: u16 {
         /// No LEDs enabled.
-        const COMMON_NONE = 0b0000_0000;
-        /// Led on common 0 enabled.
-        const COMMON_0 = 0b0000_0001;
-        /// Led on common 1 enabled.
-        const COMMON_1 = 0b0000_0010;
-        /// Led on common 2 enabled.
-        const COMMON_2 = 0b0000_0100;
-        /// Led on common 3 enabled.
-        const COMMON_3 = 0b0000_1000;
-        /// Led on common 4 enabled.
-        const COMMON_4 = 0b0001_0000;
-        /// Led on common 5 enabled.
-        const COMMON_5 = 0b0010_0000;
-        /// Led on common 6 enabled.
-        const COMMON_6 = 0b0100_0000;
-        /// Led on common 7 enabled.
-        const COMMON_7 = 0b1000_0000;
+        const ROW_NONE = 0b0000_0000_0000_0000;
+        /// Led on row 0 enabled.
+        const ROW_0 = 0b0000_0000_0000_0001;
+        /// Led on row 1 enabled.
+        const ROW_1 = 0b0000_0000_0000_0010;
+        /// Led on row 2 enabled.
+        const ROW_2 = 0b0000_0000_0000_0100;
+        /// Led on row 3 enabled.
+        const ROW_3 = 0b0000_0000_0000_1000;
+        /// Led on row 4 enabled.
+        const ROW_4 = 0b0000_0000_0001_0000;
+        /// Led on row 5 enabled.
+        const ROW_5 = 0b0000_0000_0010_0000;
+        /// Led on row 6 enabled.
+        const ROW_6 = 0b0000_0000_0100_0000;
+        /// Led on row 7 enabled.
+        const ROW_7 = 0b0000_0000_1000_0000;
+        /// Led on row 8 enabled.
+        const ROW_8 = 0b0000_0001_0000_0000;
+        /// Led on row 9 enabled.
+        const ROW_9 = 0b0000_0010_0000_0000;
+        /// Led on row 10 enabled.
+        const ROW_10 = 0b0000_0100_0000_0000;
+        /// Led on row 11 enabled.
+        const ROW_11 = 0b0000_1000_0000_0000;
+        /// Led on row 12 enabled.
+        const ROW_12 = 0b0001_0000_0000_0000;
+        /// Led on row 13 enabled.
+        const ROW_13 = 0b0010_0000_0000_0000;
+        /// Led on row 14 enabled.
+        const ROW_14 = 0b0100_0000_0000_0000;
+        /// Led on row 15 enabled.
+        const ROW_15 = 0b1000_0000_0000_0000;
     }
 }
 
 impl Default for DisplayData {
     fn default() -> DisplayData {
-        DisplayData::COMMON_NONE
+        DisplayData::ROW_NONE
     }
 }
 
 impl fmt::Display for DisplayData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            DisplayData::COMMON_NONE => write!(f, "DisplayData::COMMON_NONE"),
-            DisplayData::COMMON_0 => write!(f, "DisplayData::COMMON_0"),
-            DisplayData::COMMON_1 => write!(f, "DisplayData::COMMON_1"),
-            DisplayData::COMMON_2 => write!(f, "DisplayData::COMMON_2"),
-            DisplayData::COMMON_3 => write!(f, "DisplayData::COMMON_3"),
-            DisplayData::COMMON_4 => write!(f, "DisplayData::COMMON_4"),
-            DisplayData::COMMON_5 => write!(f, "DisplayData::COMMON_5"),
-            DisplayData::COMMON_6 => write!(f, "DisplayData::COMMON_6"),
-            DisplayData::COMMON_7 => write!(f, "DisplayData::COMMON_7"),
+            DisplayData::ROW_NONE => write!(f, "DisplayData::ROW_NONE"),
+            DisplayData::ROW_0 => write!(f, "DisplayData::ROW_0"),
+            DisplayData::ROW_1 => write!(f, "DisplayData::ROW_1"),
+            DisplayData::ROW_2 => write!(f, "DisplayData::ROW_2"),
+            DisplayData::ROW_3 => write!(f, "DisplayData::ROW_3"),
+            DisplayData::ROW_4 => write!(f, "DisplayData::ROW_4"),
+            DisplayData::ROW_5 => write!(f, "DisplayData::ROW_5"),
+            DisplayData::ROW_6 => write!(f, "DisplayData::ROW_6"),
+            DisplayData::ROW_7 => write!(f, "DisplayData::ROW_7"),
+            DisplayData::ROW_8 => write!(f, "DisplayData::ROW_8"),
+            DisplayData::ROW_9 => write!(f, "DisplayData::ROW_9"),
+            DisplayData::ROW_10 => write!(f, "DisplayData::ROW_10"),
+            DisplayData::ROW_11 => write!(f, "DisplayData::ROW_11"),
+            DisplayData::ROW_12 => write!(f, "DisplayData::ROW_12"),
+            DisplayData::ROW_13 => write!(f, "DisplayData::ROW_13"),
+            DisplayData::ROW_14 => write!(f, "DisplayData::ROW_14"),
+            DisplayData::ROW_15 => write!(f, "DisplayData::ROW_15"),
             _ => write!(f, "DisplayData::{:#10b}", self.bits()),
         }
     }

--- a/src/types/display_data.rs
+++ b/src/types/display_data.rs
@@ -53,7 +53,7 @@ impl fmt::Display for DisplayData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             DisplayData::ROW_NONE => write!(f, "DisplayData::ROW_NONE"),
-            DisplayData::ROW_0 => write!(f, "DisplayData::ROW_0"),
+            DisplayData::ROW_0 => write!(f, "DisplayData::COMMON_0"),
             DisplayData::ROW_1 => write!(f, "DisplayData::ROW_1"),
             DisplayData::ROW_2 => write!(f, "DisplayData::ROW_2"),
             DisplayData::ROW_3 => write!(f, "DisplayData::ROW_3"),
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn default() {
         assert_eq!(
-            DisplayData::COMMON_NONE,
+            DisplayData::ROW_NONE,
             DisplayData::default(),
             "DisplayData default COMMON_NONE"
         );
@@ -89,14 +89,22 @@ mod tests {
 
     #[test]
     fn all_on() {
-        let data = DisplayData::COMMON_0
-            | DisplayData::COMMON_1
-            | DisplayData::COMMON_2
-            | DisplayData::COMMON_3
-            | DisplayData::COMMON_4
-            | DisplayData::COMMON_5
-            | DisplayData::COMMON_6
-            | DisplayData::COMMON_7;
+        let data = DisplayData::ROW_0
+            | DisplayData::ROW_1
+            | DisplayData::ROW_2
+            | DisplayData::ROW_3
+            | DisplayData::ROW_4
+            | DisplayData::ROW_5
+            | DisplayData::ROW_6
+            | DisplayData::ROW_7
+            | DisplayData::ROW_8
+            | DisplayData::ROW_9
+            | DisplayData::ROW_10
+            | DisplayData::ROW_11
+            | DisplayData::ROW_12
+            | DisplayData::ROW_13
+            | DisplayData::ROW_14
+            | DisplayData::ROW_15;
 
         assert_eq!(data, DisplayData::all(), "DisplayData is all enabled");
     }

--- a/src/types/display_data_address.rs
+++ b/src/types/display_data_address.rs
@@ -53,7 +53,7 @@ mod tests {
     #[test]
     fn default() {
         assert_eq!(
-            DisplayDataAddress::ROW_0,
+            DisplayDataAddress::COMMON_0,
             DisplayDataAddress::default(),
             "DisplayDataAddress default is row 0"
         );

--- a/src/types/display_data_address.rs
+++ b/src/types/display_data_address.rs
@@ -2,68 +2,45 @@ use bitflags::bitflags;
 use core::fmt;
 
 bitflags! {
-    /// Display RAM data address.
+    /// Display RAM data address in terms of `u16`, split into bytes when
+    /// written to the 16 entries by 8 bit RAM of the HT16K33.
     pub struct DisplayDataAddress: u8 {
-        /// Row 0
-        const ROW_0 = 0;
-        /// Row 1
-        const ROW_1 = 1;
-        /// Row 2
-        const ROW_2 = 2;
-        /// Row 3
-        const ROW_3 = 3;
-        /// Row 4
-        const ROW_4 = 4;
-        /// Row 5
-        const ROW_5 = 5;
-        /// Row 6
-        const ROW_6 = 6;
-        /// Row 7
-        const ROW_7 = 7;
-        /// Row 8
-        const ROW_8 = 8;
-        /// Row 9
-        const ROW_9 = 9;
-        /// Row 10
-        const ROW_10 = 10;
-        /// Row 11
-        const ROW_11 = 11;
-        /// Row 12
-        const ROW_12 = 12;
-        /// Row 13
-        const ROW_13 = 13;
-        /// Row 14
-        const ROW_14 = 14;
-        /// Row 15
-        const ROW_15 = 15;
+        /// Common 0 Address
+        const COMMON_0 = 0;
+        /// Common 1 Address
+        const COMMON_1 = 1;
+        /// Common 2 Address
+        const COMMON_2 = 2;
+        /// Common 3 Address
+        const COMMON_3 = 3;
+        /// Common 4 Address
+        const COMMON_4 = 4;
+        /// Common 5 Address
+        const COMMON_5 = 5;
+        /// Common 6 Address
+        const COMMON_6 = 6;
+        /// Common 7 Address
+        const COMMON_7 = 7;
     }
 }
 
 impl Default for DisplayDataAddress {
     fn default() -> DisplayDataAddress {
-        DisplayDataAddress::ROW_0
+        DisplayDataAddress::COMMON_0
     }
 }
 
 impl fmt::Display for DisplayDataAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            DisplayDataAddress::ROW_0 => write!(f, "DisplayDataAddress::ROW_0"),
-            DisplayDataAddress::ROW_1 => write!(f, "DisplayDataAddress::ROW_1"),
-            DisplayDataAddress::ROW_2 => write!(f, "DisplayDataAddress::ROW_2"),
-            DisplayDataAddress::ROW_3 => write!(f, "DisplayDataAddress::ROW_3"),
-            DisplayDataAddress::ROW_4 => write!(f, "DisplayDataAddress::ROW_4"),
-            DisplayDataAddress::ROW_5 => write!(f, "DisplayDataAddress::ROW_5"),
-            DisplayDataAddress::ROW_6 => write!(f, "DisplayDataAddress::ROW_6"),
-            DisplayDataAddress::ROW_7 => write!(f, "DisplayDataAddress::ROW_7"),
-            DisplayDataAddress::ROW_8 => write!(f, "DisplayDataAddress::ROW_8"),
-            DisplayDataAddress::ROW_9 => write!(f, "DisplayDataAddress::ROW_9"),
-            DisplayDataAddress::ROW_10 => write!(f, "DisplayDataAddress::ROW_10"),
-            DisplayDataAddress::ROW_11 => write!(f, "DisplayDataAddress::ROW_11"),
-            DisplayDataAddress::ROW_12 => write!(f, "DisplayDataAddress::ROW_12"),
-            DisplayDataAddress::ROW_13 => write!(f, "DisplayDataAddress::ROW_13"),
-            DisplayDataAddress::ROW_14 => write!(f, "DisplayDataAddress::ROW_14"),
-            DisplayDataAddress::ROW_15 => write!(f, "DisplayDataAddress::ROW_15"),
+            DisplayDataAddress::COMMON_0 => write!(f, "DisplayDataAddress::COMMON_0"),
+            DisplayDataAddress::COMMON_1 => write!(f, "DisplayDataAddress::COMMON_1"),
+            DisplayDataAddress::COMMON_2 => write!(f, "DisplayDataAddress::COMMON_2"),
+            DisplayDataAddress::COMMON_3 => write!(f, "DisplayDataAddress::COMMON_3"),
+            DisplayDataAddress::COMMON_4 => write!(f, "DisplayDataAddress::COMMON_4"),
+            DisplayDataAddress::COMMON_5 => write!(f, "DisplayDataAddress::COMMON_5"),
+            DisplayDataAddress::COMMON_6 => write!(f, "DisplayDataAddress::COMMON_6"),
+            DisplayDataAddress::COMMON_7 => write!(f, "DisplayDataAddress::COMMON_7"),
             _ => write!(f, "DisplayDataAddress::{:#10b}", self.bits()),
         }
     }

--- a/src/types/led_location.rs
+++ b/src/types/led_location.rs
@@ -24,8 +24,8 @@ use core::fmt;
 ///
 /// let location = LedLocation::new(row, common)?;
 ///
-/// assert_eq!(ht16k33::DisplayDataAddress::ROW_1, location.row);
-/// assert_eq!(ht16k33::DisplayData::COMMON_2, location.common);
+/// assert_eq!(ht16k33::DisplayDataAddress::COMMON_2, location.common());
+/// assert_eq!(ht16k33::DisplayData::ROW_1, location.row());
 ///
 /// # Ok(())
 /// # }
@@ -102,7 +102,17 @@ impl LedLocation {
         Ok(LedLocation { row, common })
     }
 
-    /// Return the `common` value.
+    /// Return the Display RAM `row` address.
+    pub fn row(self) -> DisplayData {
+        self.row
+    }
+
+    /// Return the Display RAM `common` address.
+    pub fn common(self) -> DisplayDataAddress {
+        self.common
+    }
+
+    /// Return the `common` as an index into the display buffer.
     pub fn common_as_index(self) -> usize {
         self.common.bits() as usize
     }
@@ -133,8 +143,8 @@ mod tests {
         let location = LedLocation::default();
 
         assert!(
-            DisplayDataAddress::ROW_0 == location.row
-                && DisplayData::COMMON_NONE == location.common,
+            DisplayDataAddress::COMMON_0 == location.common
+                && DisplayData::ROW_NONE == location.row,
             "LedLocation default is (0, None)"
         );
     }
@@ -144,14 +154,14 @@ mod tests {
         let location = LedLocation::new(0, 0).unwrap();
 
         assert!(
-            DisplayDataAddress::ROW_0 == location.row && DisplayData::COMMON_0 == location.common,
+            DisplayDataAddress::COMMON_0 == location.common && DisplayData::ROW_0 == location.row,
             "LedLocation is (0, 0)"
         );
 
         let location = LedLocation::new(15, 7).unwrap();
 
         assert!(
-            DisplayDataAddress::ROW_15 == location.row && DisplayData::COMMON_7 == location.common,
+            DisplayDataAddress::COMMON_7 == location.common && DisplayData::ROW_15 == location.row,
             "LedLocation is (15, 7)"
         );
     }
@@ -169,8 +179,8 @@ mod tests {
     }
 
     #[test]
-    fn row_as_index() {
+    fn common_as_index() {
         let location = LedLocation::new(2, 2).unwrap();
-        assert_eq!(2usize, location.row_as_index());
+        assert_eq!(2usize, location.common_as_index());
     }
 }


### PR DESCRIPTION
The HT16K33 datasheet... isn't great. It contradicts itself on which LED maps to which bit location between the textual description (each row is a different addr, commons are bitmaps) and the table right below it (rows are bitmaps, commons take up 2 addresses):

![image](https://user-images.githubusercontent.com/6418027/210424040-41a658a2-8b51-4aac-842c-1231e6996324.png)

Before this PR, I noticed that to get all the Adafruit LED backpack LEDs to light up, I had to pass all 8 commons to `set_led`. Based on the Adafruit LED backpack [schematic](https://cdn-learn.adafruit.com/assets/assets/000/036/303/original/led_matrix_schem.png?1476210028) and the LED [datasheet](https://cdn-shop.adafruit.com/datasheets/KWL-R1230XDUGB.pdf), it's not possible for the LED backpack to use all 8 commons; there are only enough LED pins for 3 commons. With this information, I eventually figured out that the datasheet table is correct and the textual description is wrong.

I've changed the crate to swap common and row-based addressing, so that `set_led(0,0)` through `set_led(15,2)` inclusive controls the Adafruit LED backpack, rather than `set_led(0,0)` through `set_led(7,5)`. The former matches the schematic, so I believe this change is correct. If this change is accepted, it probably warrants a minor/semver-incompat release.